### PR TITLE
Please integrate this

### DIFF
--- a/app/controllers/pastes_controller.rb
+++ b/app/controllers/pastes_controller.rb
@@ -95,6 +95,7 @@ class PastesController < ApplicationController
       @project = @paste.project
     elsif User.current.admin?
       @pastes = Paste
+    else render_403
     end
 
     @pastes = @project.pastes if @project

--- a/app/helpers/pastes_helper.rb
+++ b/app/helpers/pastes_helper.rb
@@ -81,4 +81,10 @@ module PastesHelper
       { :controller => "pastes", :action => "index", :project_id => @project },
       :class => "icon icon-multiple"
   end
+
+  def link_to_new_paste
+    link_to_if_authorized "New paste", { :action => "new",
+      :project_id => @project }, :class => "icon icon-add"
+  end
+
 end

--- a/app/views/pastes/index.html.erb
+++ b/app/views/pastes/index.html.erb
@@ -10,6 +10,10 @@
 </style>
 <% end %>
 
+<div class="contextual">
+  <%= link_to_new_paste %>
+</div>
+
 <h2><%=h title %></h2>
 
 <% if @pastes.empty? %>

--- a/init.rb
+++ b/init.rb
@@ -57,10 +57,10 @@ Redmine::Plugin.register :redmine_pastebin do
   menu :project_menu, :pastes, { :controller => 'pastes', :action => 'index' },
     :caption => :label_paste_plural, :after => :label_wiki,
     :param => :project_id
-
-  menu :project_menu, :new_paste, { :controller => 'pastes', :action => 'new' },
-    :caption => :label_paste_new, :after => :label_paste_plural,
-    :param => :project_id
+# removed new pasted link from project tab to link in pastes tab
+#  menu :project_menu, :new_paste, { :controller => 'pastes', :action => 'new' },
+#    :caption => :label_paste_new, :after => :label_paste_plural,
+#    :param => :project_id
 end
 
 Redmine::Activity.map do |activity|


### PR DESCRIPTION
Made a bug fix which only shows 404 isntead of internal error when nion admin acccesses /pastes URL

_Changes_
We don't like that "New Paste" is now part of the project menu. Its already enough tabs in our projects menu - eg. new issue is to be request not part or projects menu also.
So we removed the entry from the menu and put "Redmine alike" a "new Paste" link on the upper right of the "Pastes" view tab, which is also part of the project menu (again: one tab is enough per modul)
